### PR TITLE
Add SQLite-based full-stack desktop task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # ChatGPT
-test
+
+This repository contains a task management application with user authentication.
+When a graphical display is available, it launches a Tkinter GUI starting with a
+login screen. Otherwise, it falls back to a console interface so you can still
+manage tasks over a terminal.
+
+## Running the Application
+
+Ensure you have Python installed (version 3.8+ recommended). Tkinter is typically
+included with standard Python installations. Run the application with:
+
+```bash
+python tasks_app.py
+```
+
+User accounts and tasks are stored in the SQLite database `app.db` in the project
+directory. If no GUI display is detected, the script automatically runs in console
+mode. After logging in you can use simple commands (`add`, `remove`, `done`,
+`quit`) to manage tasks.

--- a/tasks_app.py
+++ b/tasks_app.py
@@ -1,0 +1,259 @@
+import tkinter as tk
+from tkinter import messagebox, simpledialog
+import os
+import sqlite3
+import hashlib
+from tkinter import ttk
+
+DB_FILE = 'app.db'
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+def init_db():
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE,
+            password TEXT
+        )
+        """
+    )
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            description TEXT,
+            done INTEGER DEFAULT 0,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+def load_tasks(user_id):
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute("SELECT id, description, done FROM tasks WHERE user_id=?", (user_id,))
+    tasks = [
+        {"id": row[0], "description": row[1], "done": bool(row[2])} for row in c.fetchall()
+    ]
+    conn.close()
+    return tasks
+
+def add_task_db(user_id, desc):
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute("INSERT INTO tasks (user_id, description) VALUES (?, ?)", (user_id, desc))
+    conn.commit()
+    conn.close()
+
+def remove_task_db(task_id):
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute("DELETE FROM tasks WHERE id=?", (task_id,))
+    conn.commit()
+    conn.close()
+
+def mark_done_db(task_id):
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute("UPDATE tasks SET done=1 WHERE id=?", (task_id,))
+    conn.commit()
+    conn.close()
+
+def get_user(username, password):
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute("SELECT id, password FROM users WHERE username=?", (username,))
+    row = c.fetchone()
+    conn.close()
+    if row and row[1] == hash_password(password):
+        return row[0]
+    return None
+
+def register_user(username, password) -> bool:
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    try:
+        c.execute("INSERT INTO users (username, password) VALUES (?, ?)", (username, hash_password(password)))
+        conn.commit()
+        return True
+    except sqlite3.IntegrityError:
+        return False
+    finally:
+        conn.close()
+
+
+class LoginWindow(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Login")
+        self.geometry("300x150")
+
+        ttk.Label(self, text="Username:").pack(pady=(10, 0))
+        self.username_var = tk.StringVar()
+        ttk.Entry(self, textvariable=self.username_var).pack(fill=tk.X, padx=20)
+
+        ttk.Label(self, text="Password:").pack(pady=(10, 0))
+        self.password_var = tk.StringVar()
+        ttk.Entry(self, textvariable=self.password_var, show="*").pack(fill=tk.X, padx=20)
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack(pady=10)
+
+        ttk.Button(btn_frame, text="Login", command=self.login).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Register", command=self.register).pack(side=tk.LEFT, padx=5)
+
+    def login(self):
+        username = self.username_var.get().strip()
+        password = self.password_var.get().strip()
+        user_id = get_user(username, password)
+        if user_id:
+            self.destroy()
+            app = TaskApp(user_id, username)
+            app.mainloop()
+        else:
+            messagebox.showerror("Login Failed", "Invalid credentials")
+
+    def register(self):
+        username = self.username_var.get().strip()
+        password = self.password_var.get().strip()
+        if register_user(username, password):
+            messagebox.showinfo("Register", "Account created. You can now log in.")
+        else:
+            messagebox.showerror("Register", "Username already exists")
+
+class TaskApp(tk.Tk):
+    def __init__(self, user_id, username):
+        super().__init__()
+        self.title(f'Tasks - {username}')
+        self.geometry('300x400')
+
+        self.user_id = user_id
+        self.tasks = load_tasks(user_id)
+
+        self.task_listbox = tk.Listbox(self, selectmode=tk.SINGLE)
+        self.task_listbox.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        button_frame = ttk.Frame(self)
+        button_frame.pack(fill=tk.X, padx=10)
+
+        add_btn = ttk.Button(button_frame, text='Add Task', command=self.add_task)
+        add_btn.pack(side=tk.LEFT, expand=True, fill=tk.X)
+
+        remove_btn = ttk.Button(button_frame, text='Remove', command=self.remove_task)
+        remove_btn.pack(side=tk.LEFT, expand=True, fill=tk.X)
+
+        done_btn = ttk.Button(button_frame, text='Mark Done', command=self.mark_done)
+        done_btn.pack(side=tk.LEFT, expand=True, fill=tk.X)
+
+        self.refresh_tasks()
+
+    def add_task(self):
+        task = simpledialog.askstring('New Task', 'Enter task description:')
+        if task:
+            add_task_db(self.user_id, task)
+            self.tasks = load_tasks(self.user_id)
+            self.refresh_tasks()
+
+    def remove_task(self):
+        idx = self.task_listbox.curselection()
+        if not idx:
+            messagebox.showwarning('Remove Task', 'No task selected')
+            return
+        task_id = self.tasks[idx[0]]["id"]
+        remove_task_db(task_id)
+        self.tasks = load_tasks(self.user_id)
+        self.refresh_tasks()
+
+    def mark_done(self):
+        idx = self.task_listbox.curselection()
+        if not idx:
+            messagebox.showwarning('Mark Done', 'No task selected')
+            return
+        task_id = self.tasks[idx[0]]["id"]
+        mark_done_db(task_id)
+        self.tasks = load_tasks(self.user_id)
+        self.refresh_tasks()
+
+    def refresh_tasks(self):
+        self.task_listbox.delete(0, tk.END)
+        self.tasks = load_tasks(self.user_id)
+        for task in self.tasks:
+            desc = task['description']
+            if task.get('done'):
+                desc += ' [DONE]'
+            self.task_listbox.insert(tk.END, desc)
+
+def print_tasks(tasks):
+    if not tasks:
+        print("No tasks available.")
+    for i, task in enumerate(tasks, 1):
+        status = "[DONE]" if task.get('done') else ""
+        print(f"{i}. {task['description']} {status}")
+
+
+def run_cli():
+    init_db()
+    username = input("Username: ").strip()
+    password = input("Password: ").strip()
+    user_id = get_user(username, password)
+    if not user_id:
+        choice = input("User not found. Register? (y/n): ").lower()
+        if choice == 'y':
+            if register_user(username, password):
+                user_id = get_user(username, password)
+            else:
+                print("Registration failed")
+                return
+        else:
+            return
+
+    while True:
+        tasks = load_tasks(user_id)
+        print("\nCurrent tasks:")
+        print_tasks(tasks)
+        cmd = input("\nCommand (add/remove/done/quit): ").strip().lower()
+        if cmd == 'add':
+            desc = input("Task description: ").strip()
+            if desc:
+                add_task_db(user_id, desc)
+        elif cmd.startswith('remove'):
+            parts = cmd.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                idx = int(parts[1]) - 1
+                if 0 <= idx < len(tasks):
+                    remove_task_db(tasks[idx]['id'])
+                else:
+                    print("Invalid index")
+            else:
+                print("Usage: remove <task number>")
+        elif cmd.startswith('done'):
+            parts = cmd.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                idx = int(parts[1]) - 1
+                if 0 <= idx < len(tasks):
+                    mark_done_db(tasks[idx]['id'])
+                else:
+                    print("Invalid index")
+            else:
+                print("Usage: done <task number>")
+        elif cmd == 'quit':
+            break
+        else:
+            print("Unknown command")
+
+
+if __name__ == '__main__':
+    init_db()
+    if os.environ.get('DISPLAY'):
+        LoginWindow().mainloop()
+    else:
+        print("No display found. Running in console mode.")
+        run_cli()


### PR DESCRIPTION
## Summary
- implement SQLite database for user accounts and tasks
- add login window and modernize the GUI with ttk widgets
- update CLI to require authentication
- document new database and login workflow in README

## Testing
- `python tasks_app.py` *(starts CLI login due to no display)*

------
https://chatgpt.com/codex/tasks/task_e_684976004f98832f9fccb4129632d2fc