### PR TITLE
Add realtime CRUD endpoints and client updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # ChatGPT
-test
+
+This repository contains two versions of a task manager.
+
+* `tasks_app.py` – a Python/Tkinter implementation that falls back to a CLI when no display is available.
+* `react-native-app` and `server` – a React Native Windows application backed by a Node.js/Express API with PostgreSQL.
+
+## Running the Python Application
+
+Ensure you have Python installed (version 3.8+ recommended). Tkinter is typically included with standard Python installations. Run the application with:
+
+```bash
+python tasks_app.py
+```
+
+User accounts and tasks are stored in the SQLite database `app.db` in the project directory. If no GUI display is detected, the script automatically runs in console mode.
+
+## Running the React Native + Node Application
+
+1. Populate `server/.env` based on `server/.env.example` with your PostgreSQL connection string.
+2. From `server/` run `npm install` then `npm start` to launch the API on port 3001.
+3. From `react-native-app/` run `npm install` and `npm start` to launch the React Native bundler.
+
+The React Native app now features a dashboard with sections for tasks, projects, events and expenses. Reusable components keep the interface minimalistic. The Express backend exposes CRUD endpoints for all resources and provides a `/api/stream` Server-Sent Events endpoint so the client can refresh lists when data changes.

--- a/react-native-app/App.js
+++ b/react-native-app/App.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './src/screens/LoginScreen';
+import DashboardScreen from './src/screens/DashboardScreen';
+import TaskScreen from './src/screens/TaskScreen';
+import ProjectsScreen from './src/screens/ProjectsScreen';
+import EventsScreen from './src/screens/EventsScreen';
+import ExpensesScreen from './src/screens/ExpensesScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+        <Stack.Screen name="Tasks" component={TaskScreen} />
+        <Stack.Screen name="Projects" component={ProjectsScreen} />
+        <Stack.Screen name="Events" component={EventsScreen} />
+        <Stack.Screen name="Expenses" component={ExpensesScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/react-native-app/index.js
+++ b/react-native-app/index.js
@@ -1,0 +1,4 @@
+import { AppRegistry } from 'react-native';
+import App from './App';
+
+AppRegistry.registerComponent('TaskManager', () => App);

--- a/react-native-app/package.json
+++ b/react-native-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "task-manager-app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "react-native start"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "react-native-paper": "5.10.0",
+    "axios": "1.6.0",
+    "@react-navigation/native": "6.1.7",
+    "@react-navigation/native-stack": "6.9.12"
+  }
+}

--- a/react-native-app/src/components/ItemList.js
+++ b/react-native-app/src/components/ItemList.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FlatList } from 'react-native';
+import { List } from 'react-native-paper';
+
+export default function ItemList({ items, onPressItem, onLongPressItem }) {
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={(item) => item.id.toString()}
+      renderItem={({ item }) => (
+        <List.Item
+          title={item.name || item.description}
+          onPress={() => onPressItem && onPressItem(item)}
+          onLongPress={() => onLongPressItem && onLongPressItem(item)}
+        />
+      )}
+    />
+  );
+}

--- a/react-native-app/src/components/TaskList.js
+++ b/react-native-app/src/components/TaskList.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ItemList from './ItemList';
+
+export default function TaskList({ tasks, onToggle, onDelete }) {
+  const items = tasks.map((t) => ({
+    ...t,
+    name: t.description + (t.done ? ' [DONE]' : ''),
+  }));
+  return (
+    <ItemList
+      items={items}
+      onPressItem={onToggle}
+      onLongPressItem={onDelete}
+    />
+  );
+}

--- a/react-native-app/src/screens/DashboardScreen.js
+++ b/react-native-app/src/screens/DashboardScreen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Button } from 'react-native-paper';
+
+export default function DashboardScreen({ navigation, route }) {
+  const { userId } = route.params;
+  return (
+    <View style={{ padding: 20 }}>
+      <Button mode="contained" onPress={() => navigation.navigate('Tasks', { userId })} style={{ marginBottom: 10 }}>
+        Tasks
+      </Button>
+      <Button mode="contained" onPress={() => navigation.navigate('Projects', { userId })} style={{ marginBottom: 10 }}>
+        Projects
+      </Button>
+      <Button mode="contained" onPress={() => navigation.navigate('Events', { userId })} style={{ marginBottom: 10 }}>
+        Events
+      </Button>
+      <Button mode="contained" onPress={() => navigation.navigate('Expenses', { userId })}>
+        Expenses
+      </Button>
+    </View>
+  );
+}

--- a/react-native-app/src/screens/EventsScreen.js
+++ b/react-native-app/src/screens/EventsScreen.js
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { View } from 'react-native';
+import { TextInput, Button } from 'react-native-paper';
+import ItemList from '../components/ItemList';
+import axios from 'axios';
+
+export default function EventsScreen({ route }) {
+  const { userId } = route.params;
+  const [events, setEvents] = useState([]);
+  const [name, setName] = useState('');
+
+  const loadEvents = async () => {
+    const res = await axios.get('http://localhost:3001/api/events', { params: { userId } });
+    setEvents(res.data);
+  };
+
+  const addEvent = async () => {
+    await axios.post('http://localhost:3001/api/events', { userId, name });
+    setName('');
+    loadEvents();
+  };
+
+  const deleteEvent = async (item) => {
+    await axios.delete(`http://localhost:3001/api/events/${item.id}`);
+    loadEvents();
+  };
+
+  useEffect(() => {
+    loadEvents();
+    const es = new EventSource('http://localhost:3001/api/stream');
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if (data.type === 'events') loadEvents();
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput label="Event name" value={name} onChangeText={setName} />
+      <Button onPress={addEvent} mode="contained" style={{ marginTop: 10 }}>
+        Add
+      </Button>
+      <ItemList items={events} onLongPressItem={deleteEvent} />
+    </View>
+  );
+}

--- a/react-native-app/src/screens/ExpensesScreen.js
+++ b/react-native-app/src/screens/ExpensesScreen.js
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { View } from 'react-native';
+import { TextInput, Button } from 'react-native-paper';
+import ItemList from '../components/ItemList';
+import axios from 'axios';
+
+export default function ExpensesScreen({ route }) {
+  const { userId } = route.params;
+  const [expenses, setExpenses] = useState([]);
+  const [name, setName] = useState('');
+
+  const loadExpenses = async () => {
+    const res = await axios.get('http://localhost:3001/api/expenses', { params: { userId } });
+    setExpenses(res.data);
+  };
+
+  const addExpense = async () => {
+    await axios.post('http://localhost:3001/api/expenses', { userId, name });
+    setName('');
+    loadExpenses();
+  };
+
+  const deleteExpense = async (item) => {
+    await axios.delete(`http://localhost:3001/api/expenses/${item.id}`);
+    loadExpenses();
+  };
+
+  useEffect(() => {
+    loadExpenses();
+    const es = new EventSource('http://localhost:3001/api/stream');
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if (data.type === 'expenses') loadExpenses();
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput label="Expense" value={name} onChangeText={setName} />
+      <Button onPress={addExpense} mode="contained" style={{ marginTop: 10 }}>
+        Add
+      </Button>
+      <ItemList items={expenses} onLongPressItem={deleteExpense} />
+    </View>
+  );
+}

--- a/react-native-app/src/screens/LoginScreen.js
+++ b/react-native-app/src/screens/LoginScreen.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import { TextInput, Button, Text } from 'react-native-paper';
+import axios from 'axios';
+
+export default function LoginScreen({ navigation }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const login = async () => {
+    try {
+      const res = await axios.post('http://localhost:3001/api/login', { username, password });
+      navigation.replace('Dashboard', { userId: res.data.userId });
+    } catch (e) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput label="Username" value={username} onChangeText={setUsername} />
+      <TextInput label="Password" value={password} secureTextEntry onChangeText={setPassword} style={{ marginTop: 10 }} />
+      {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}
+      <Button mode="contained" onPress={login} style={{ marginTop: 20 }}>
+        Login
+      </Button>
+    </View>
+  );
+}

--- a/react-native-app/src/screens/ProjectsScreen.js
+++ b/react-native-app/src/screens/ProjectsScreen.js
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import { View } from 'react-native';
+import { TextInput, Button } from 'react-native-paper';
+import ItemList from '../components/ItemList';
+import axios from 'axios';
+
+export default function ProjectsScreen({ route }) {
+  const { userId } = route.params;
+  const [projects, setProjects] = useState([]);
+  const [name, setName] = useState('');
+
+  const loadProjects = async () => {
+    const res = await axios.get('http://localhost:3001/api/projects', { params: { userId } });
+    setProjects(res.data);
+  };
+
+  const addProject = async () => {
+    await axios.post('http://localhost:3001/api/projects', { userId, name });
+    setName('');
+    loadProjects();
+  };
+
+  const deleteProject = async (item) => {
+    await axios.delete(`http://localhost:3001/api/projects/${item.id}`);
+    loadProjects();
+  };
+
+  useEffect(() => {
+    loadProjects();
+    const es = new EventSource('http://localhost:3001/api/stream');
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if (data.type === 'projects') loadProjects();
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput label="Project name" value={name} onChangeText={setName} />
+      <Button onPress={addProject} mode="contained" style={{ marginTop: 10 }}>
+        Add
+      </Button>
+      <ItemList items={projects} onLongPressItem={deleteProject} />
+    </View>
+  );
+}

--- a/react-native-app/src/screens/TaskScreen.js
+++ b/react-native-app/src/screens/TaskScreen.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import { View } from 'react-native';
+import { TextInput, Button } from 'react-native-paper';
+import TaskList from '../components/TaskList';
+import axios from 'axios';
+
+export default function TaskScreen({ route }) {
+  const { userId } = route.params;
+  const [tasks, setTasks] = useState([]);
+  const [desc, setDesc] = useState('');
+
+  const loadTasks = async () => {
+    const res = await axios.get('http://localhost:3001/api/tasks', { params: { userId } });
+    setTasks(res.data);
+  };
+
+  const addTask = async () => {
+    await axios.post('http://localhost:3001/api/tasks', { userId, description: desc });
+    setDesc('');
+    loadTasks();
+  };
+
+  const toggleTask = async (task) => {
+    await axios.put(`http://localhost:3001/api/tasks/${task.id}`, {
+      description: task.description,
+      assigneeId: task.assignee_id,
+      done: !task.done,
+    });
+    loadTasks();
+  };
+
+  const deleteTask = async (task) => {
+    await axios.delete(`http://localhost:3001/api/tasks/${task.id}`);
+    loadTasks();
+  };
+
+  useEffect(() => {
+    loadTasks();
+    const es = new EventSource('http://localhost:3001/api/stream');
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if (data.type === 'tasks') loadTasks();
+    };
+    return () => es.close();
+  }, []);
+
+  return (
+    <View style={{ padding: 20 }}>
+      <TextInput label="Task description" value={desc} onChangeText={setDesc} />
+      <Button onPress={addTask} mode="contained" style={{ marginTop: 10 }}>
+        Add
+      </Button>
+      <TaskList tasks={tasks} onToggle={toggleTask} onDelete={deleteTask} />
+    </View>
+  );
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/tasks_db

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,14 @@
+# Task Manager Server
+
+This Express backend uses PostgreSQL for storing users, tasks, projects, events and expenses. Create a `.env` file based on `.env.example` with your database connection string.
+
+## Development
+
+Install dependencies and run:
+
+```bash
+npm install
+npm start
+```
+
+The server exposes endpoints under `/api` for login, tasks, projects, events and expenses. Each resource supports create, update and delete operations. A `/api/stream` endpoint delivers real-time notifications via Server-Sent Events.

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,15 @@
+import pkg from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { Pool } = pkg;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export async function query(text, params) {
+  const res = await pool.query(text, params);
+  return res.rows;
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "task-manager-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.19.2",
+    "pg": "^8.11.1"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,191 @@
+import express from 'express';
+import cors from 'cors';
+import bcrypt from 'bcrypt';
+import { query } from './db.js';
+
+const clients = [];
+
+function broadcast(update) {
+  const data = `data: ${JSON.stringify(update)}\n\n`;
+  clients.forEach((res) => res.write(data));
+}
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+async function init() {
+  await query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+
+  await query(`CREATE TABLE IF NOT EXISTS tasks (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER,
+    description TEXT,
+    assignee_id INTEGER,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+  )`);
+
+  await query(`CREATE TABLE IF NOT EXISTS projects (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER,
+    name TEXT
+  )`);
+
+  await query(`CREATE TABLE IF NOT EXISTS events (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER,
+    name TEXT
+  )`);
+
+  await query(`CREATE TABLE IF NOT EXISTS expenses (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER,
+    name TEXT
+  )`);
+}
+
+init();
+
+app.get('/api/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.write('\n');
+  clients.push(res);
+  req.on('close', () => {
+    const idx = clients.indexOf(res);
+    if (idx !== -1) clients.splice(idx, 1);
+  });
+});
+
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  const rows = await query('SELECT id, password FROM users WHERE username=$1', [username]);
+  const user = rows[0];
+  if (user && await bcrypt.compare(password, user.password)) {
+    res.json({ userId: user.id });
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
+});
+
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    await query('INSERT INTO users (username, password) VALUES ($1, $2)', [username, hashed]);
+    res.status(201).end();
+  } catch (err) {
+    res.status(400).json({ error: 'User exists' });
+  }
+});
+
+app.get('/api/tasks', async (req, res) => {
+  const { userId } = req.query;
+  const tasks = await query('SELECT * FROM tasks WHERE user_id=$1', [userId]);
+  res.json(tasks);
+});
+
+app.post('/api/tasks', async (req, res) => {
+  const { userId, description, assigneeId } = req.body;
+  await query('INSERT INTO tasks (user_id, description, assignee_id) VALUES ($1, $2, $3)', [userId, description, assigneeId]);
+  broadcast({ type: 'tasks' });
+  res.status(201).end();
+});
+
+app.put('/api/tasks/:id', async (req, res) => {
+  const { description, assigneeId, done } = req.body;
+  await query('UPDATE tasks SET description=$1, assignee_id=$2, done=$3 WHERE id=$4', [description, assigneeId, done, req.params.id]);
+  broadcast({ type: 'tasks' });
+  res.end();
+});
+
+app.delete('/api/tasks/:id', async (req, res) => {
+  await query('DELETE FROM tasks WHERE id=$1', [req.params.id]);
+  broadcast({ type: 'tasks' });
+  res.end();
+});
+
+app.get('/api/projects', async (req, res) => {
+  const { userId } = req.query;
+  const rows = await query('SELECT * FROM projects WHERE user_id=$1', [userId]);
+  res.json(rows);
+});
+
+app.post('/api/projects', async (req, res) => {
+  const { userId, name } = req.body;
+  await query('INSERT INTO projects (user_id, name) VALUES ($1, $2)', [userId, name]);
+  broadcast({ type: 'projects' });
+  res.status(201).end();
+});
+
+app.put('/api/projects/:id', async (req, res) => {
+  const { name } = req.body;
+  await query('UPDATE projects SET name=$1 WHERE id=$2', [name, req.params.id]);
+  broadcast({ type: 'projects' });
+  res.end();
+});
+
+app.delete('/api/projects/:id', async (req, res) => {
+  await query('DELETE FROM projects WHERE id=$1', [req.params.id]);
+  broadcast({ type: 'projects' });
+  res.end();
+});
+
+app.get('/api/events', async (req, res) => {
+  const { userId } = req.query;
+  const rows = await query('SELECT * FROM events WHERE user_id=$1', [userId]);
+  res.json(rows);
+});
+
+app.post('/api/events', async (req, res) => {
+  const { userId, name } = req.body;
+  await query('INSERT INTO events (user_id, name) VALUES ($1, $2)', [userId, name]);
+  broadcast({ type: 'events' });
+  res.status(201).end();
+});
+
+app.put('/api/events/:id', async (req, res) => {
+  const { name } = req.body;
+  await query('UPDATE events SET name=$1 WHERE id=$2', [name, req.params.id]);
+  broadcast({ type: 'events' });
+  res.end();
+});
+
+app.delete('/api/events/:id', async (req, res) => {
+  await query('DELETE FROM events WHERE id=$1', [req.params.id]);
+  broadcast({ type: 'events' });
+  res.end();
+});
+
+app.get('/api/expenses', async (req, res) => {
+  const { userId } = req.query;
+  const rows = await query('SELECT * FROM expenses WHERE user_id=$1', [userId]);
+  res.json(rows);
+});
+
+app.post('/api/expenses', async (req, res) => {
+  const { userId, name } = req.body;
+  await query('INSERT INTO expenses (user_id, name) VALUES ($1, $2)', [userId, name]);
+  broadcast({ type: 'expenses' });
+  res.status(201).end();
+});
+
+app.put('/api/expenses/:id', async (req, res) => {
+  const { name } = req.body;
+  await query('UPDATE expenses SET name=$1 WHERE id=$2', [name, req.params.id]);
+  broadcast({ type: 'expenses' });
+  res.end();
+});
+
+app.delete('/api/expenses/:id', async (req, res) => {
+  await query('DELETE FROM expenses WHERE id=$1', [req.params.id]);
+  broadcast({ type: 'expenses' });
+  res.end();
+});
+
+app.listen(3001, () => console.log('Server running on port 3001'));

--- a/tasks_app.py
+++ b/tasks_app.py
@@ -1,0 +1,251 @@
+import tkinter as tk
+from tkinter import messagebox, simpledialog
+import os
+import sqlite3
+import hashlib
+from pathlib import Path
+from tkinter import ttk
+
+# Database file lives in the same directory as this script
+DB_FILE = str(Path(__file__).with_name('app.db'))
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+def init_db():
+    """Create required tables if they do not exist."""
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE,
+                password TEXT
+            )
+            """
+        )
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                description TEXT,
+                done INTEGER DEFAULT 0,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )
+            """
+        )
+
+def load_tasks(user_id):
+    """Return a list of task dicts for the given user."""
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("SELECT id, description, done FROM tasks WHERE user_id=?", (user_id,))
+        rows = c.fetchall()
+    return [
+        {"id": row[0], "description": row[1], "done": bool(row[2])} for row in rows
+    ]
+
+def add_task_db(user_id, desc):
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute(
+            "INSERT INTO tasks (user_id, description) VALUES (?, ?)", (user_id, desc)
+        )
+
+def remove_task_db(task_id):
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute("DELETE FROM tasks WHERE id=?", (task_id,))
+
+def mark_done_db(task_id):
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute("UPDATE tasks SET done=1 WHERE id=?", (task_id,))
+
+def get_user(username, password):
+    with sqlite3.connect(DB_FILE) as conn:
+        c = conn.cursor()
+        c.execute("SELECT id, password FROM users WHERE username=?", (username,))
+        row = c.fetchone()
+    if row and row[1] == hash_password(password):
+        return row[0]
+    return None
+
+def register_user(username, password) -> bool:
+    try:
+        with sqlite3.connect(DB_FILE) as conn:
+            conn.execute(
+                "INSERT INTO users (username, password) VALUES (?, ?)",
+                (username, hash_password(password)),
+            )
+        return True
+    except sqlite3.IntegrityError:
+        return False
+
+
+class LoginWindow(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Login")
+        self.geometry("300x150")
+
+        ttk.Label(self, text="Username:").pack(pady=(10, 0))
+        self.username_var = tk.StringVar()
+        ttk.Entry(self, textvariable=self.username_var).pack(fill=tk.X, padx=20)
+
+        ttk.Label(self, text="Password:").pack(pady=(10, 0))
+        self.password_var = tk.StringVar()
+        ttk.Entry(self, textvariable=self.password_var, show="*").pack(fill=tk.X, padx=20)
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack(pady=10)
+
+        ttk.Button(btn_frame, text="Login", command=self.login).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Register", command=self.register).pack(side=tk.LEFT, padx=5)
+
+    def login(self):
+        username = self.username_var.get().strip()
+        password = self.password_var.get().strip()
+        user_id = get_user(username, password)
+        if user_id:
+            self.destroy()
+            app = TaskApp(user_id, username)
+            app.mainloop()
+        else:
+            messagebox.showerror("Login Failed", "Invalid credentials")
+
+    def register(self):
+        username = self.username_var.get().strip()
+        password = self.password_var.get().strip()
+        if register_user(username, password):
+            messagebox.showinfo("Register", "Account created. You can now log in.")
+        else:
+            messagebox.showerror("Register", "Username already exists")
+
+class TaskApp(tk.Tk):
+    def __init__(self, user_id, username):
+        super().__init__()
+        self.title(f'Tasks - {username}')
+        self.geometry('300x400')
+
+        self.user_id = user_id
+        self.tasks = load_tasks(user_id)
+
+        self.task_listbox = tk.Listbox(self, selectmode=tk.SINGLE)
+        self.task_listbox.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        button_frame = ttk.Frame(self)
+        button_frame.pack(fill=tk.X, padx=10)
+
+        add_btn = ttk.Button(button_frame, text='Add Task', command=self.add_task)
+        add_btn.pack(side=tk.LEFT, expand=True, fill=tk.X)
+
+        remove_btn = ttk.Button(button_frame, text='Remove', command=self.remove_task)
+        remove_btn.pack(side=tk.LEFT, expand=True, fill=tk.X)
+
+        done_btn = ttk.Button(button_frame, text='Mark Done', command=self.mark_done)
+        done_btn.pack(side=tk.LEFT, expand=True, fill=tk.X)
+
+        self.refresh_tasks()
+
+    def add_task(self):
+        task = simpledialog.askstring('New Task', 'Enter task description:')
+        if task:
+            add_task_db(self.user_id, task)
+            self.tasks = load_tasks(self.user_id)
+            self.refresh_tasks()
+
+    def remove_task(self):
+        idx = self.task_listbox.curselection()
+        if not idx:
+            messagebox.showwarning('Remove Task', 'No task selected')
+            return
+        task_id = self.tasks[idx[0]]["id"]
+        remove_task_db(task_id)
+        self.tasks = load_tasks(self.user_id)
+        self.refresh_tasks()
+
+    def mark_done(self):
+        idx = self.task_listbox.curselection()
+        if not idx:
+            messagebox.showwarning('Mark Done', 'No task selected')
+            return
+        task_id = self.tasks[idx[0]]["id"]
+        mark_done_db(task_id)
+        self.tasks = load_tasks(self.user_id)
+        self.refresh_tasks()
+
+    def refresh_tasks(self):
+        self.task_listbox.delete(0, tk.END)
+        self.tasks = load_tasks(self.user_id)
+        for task in self.tasks:
+            desc = task['description']
+            if task.get('done'):
+                desc += ' [DONE]'
+            self.task_listbox.insert(tk.END, desc)
+
+def print_tasks(tasks):
+    if not tasks:
+        print("No tasks available.")
+    for i, task in enumerate(tasks, 1):
+        status = "[DONE]" if task.get('done') else ""
+        print(f"{i}. {task['description']} {status}")
+
+
+def run_cli():
+    init_db()
+    username = input("Username: ").strip()
+    password = input("Password: ").strip()
+    user_id = get_user(username, password)
+    if not user_id:
+        choice = input("User not found. Register? (y/n): ").lower()
+        if choice == 'y':
+            if register_user(username, password):
+                user_id = get_user(username, password)
+            else:
+                print("Registration failed")
+                return
+        else:
+            return
+
+    while True:
+        tasks = load_tasks(user_id)
+        print("\nCurrent tasks:")
+        print_tasks(tasks)
+        cmd = input("\nCommand (add/remove/done/quit): ").strip().lower()
+        if cmd == 'add':
+            desc = input("Task description: ").strip()
+            if desc:
+                add_task_db(user_id, desc)
+        elif cmd.startswith('remove'):
+            parts = cmd.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                idx = int(parts[1]) - 1
+                if 0 <= idx < len(tasks):
+                    remove_task_db(tasks[idx]['id'])
+                else:
+                    print("Invalid index")
+            else:
+                print("Usage: remove <task number>")
+        elif cmd.startswith('done'):
+            parts = cmd.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                idx = int(parts[1]) - 1
+                if 0 <= idx < len(tasks):
+                    mark_done_db(tasks[idx]['id'])
+                else:
+                    print("Invalid index")
+            else:
+                print("Usage: done <task number>")
+        elif cmd == 'quit':
+            break
+        else:
+            print("Unknown command")
+
+
+if __name__ == '__main__':
+    init_db()
+    if os.environ.get('DISPLAY'):
+        LoginWindow().mainloop()
+    else:
+        print("No display found. Running in console mode.")
+        run_cli()


### PR DESCRIPTION
## Summary
- add ItemList callbacks and extend TaskList for toggle/delete
- update Task, Projects, Events and Expenses screens with realtime refresh and remove actions
- implement CRUD API for all resources with SSE notifications
- document `/api/stream` endpoint in README files

## Testing
- `python -m py_compile tasks_app.py`
- `node --check server/server.js`
- `node --check react-native-app/index.js`
- `node --check react-native-app/App.js`
- `node --check react-native-app/src/screens/LoginScreen.js`
- `node --check react-native-app/src/screens/TaskScreen.js`
- `node --check react-native-app/src/screens/ProjectsScreen.js`
- `node --check react-native-app/src/screens/EventsScreen.js`
- `node --check react-native-app/src/screens/ExpensesScreen.js`
- `node --check react-native-app/src/components/ItemList.js`
- `node --check react-native-app/src/components/TaskList.js`


------
https://chatgpt.com/codex/tasks/task_e_684976004f98832f9fccb4129632d2fc